### PR TITLE
Fix rollback table name for objects migration

### DIFF
--- a/database/migrations/2025_08_17_194602_create_objects_table.php
+++ b/database/migrations/2025_08_17_194602_create_objects_table.php
@@ -28,6 +28,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('realties');
+        Schema::dropIfExists('objects');
     }
 };


### PR DESCRIPTION
## Summary
- drop `objects` table on rollback instead of `realties`

## Testing
- `php artisan migrate`
- `php artisan migrate:rollback`
- `php artisan migrate`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b76d6947888324b93e174566ed45b8