### PR TITLE
Refactor object type usage to enum constants

### DIFF
--- a/app/Console/Commands/GeoCoder.php
+++ b/app/Console/Commands/GeoCoder.php
@@ -39,7 +39,7 @@ class GeoCoder extends Command
      */
     public function handle(): void
     {
-        AbandonedObject::where('type', 1)
+        AbandonedObject::where('type', AbandonedObjectTypeEnum::HOUSE->value)
             ->whereNull('coords')
             ->whereNotNull('address')
             ->chunk(200, function ($objects) {

--- a/app/Console/Commands/ParseObjects.php
+++ b/app/Console/Commands/ParseObjects.php
@@ -23,7 +23,7 @@ class ParseObjects extends Command
      *
      * @var string
      */
-    protected $signature = 'parse {--type=2} {--state=15}';
+    protected $signature = 'parse {--type=} {--state=15}';
 
     /**
      * The console command description.
@@ -37,7 +37,7 @@ class ParseObjects extends Command
      */
     public function handle(): void
     {
-        $type = (int) $this->option('type');
+        $type = (int) ($this->option('type') ?? AbandonedObjectTypeEnum::LAND_PLOT->value);
         $sateId = (int) $this->option('state');
 
         $this->info("Запрашиваю данные для типа #".AbandonedObjectTypeEnum::from($type)->label()." в статусе #".ObjectStateEnum::from($sateId)->label()."...");

--- a/app/Console/Commands/SyncInvestmentBorders.php
+++ b/app/Console/Commands/SyncInvestmentBorders.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\AbandonedObjectTypeEnum;
 use Illuminate\Console\Command;
 use App\Services\InvestmentBordersSyncService;
 
@@ -11,7 +12,13 @@ class SyncInvestmentBorders extends Command
                             {--all : Обновлять все (включая те, где borders уже заполнено)}
                             {--limit= : Лимит записей за запуск}';
 
-    protected $description = 'Синхронизация borders для инвест-объектов (type=2) из ERI2 API';
+    protected $description;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->description = 'Синхронизация borders для инвест-объектов (type=' . AbandonedObjectTypeEnum::LAND_PLOT->value . ') из ERI2 API';
+    }
 
     public function handle(InvestmentBordersSyncService $service): int
     {
@@ -19,7 +26,8 @@ class SyncInvestmentBorders extends Command
         $limit = $this->option('limit') ? (int)$this->option('limit') : null;
 
         $this->info(sprintf(
-            'Старт: type=2, onlyMissing=%s, limit=%s',
+            'Старт: type=%d, onlyMissing=%s, limit=%s',
+            AbandonedObjectTypeEnum::LAND_PLOT->value,
             $onlyMissing ? 'true' : 'false',
             $limit ?? '—'
         ));

--- a/app/Services/InvestmentBordersSyncService.php
+++ b/app/Services/InvestmentBordersSyncService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\AbandonedObjectTypeEnum;
 use App\Models\AbandonedObject;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -9,7 +10,7 @@ use Illuminate\Support\Facades\Log;
 class InvestmentBordersSyncService
 {
     /**
-     * Пробегает по объектам (type=2), тянет borders и сохраняет.
+     * Пробегает по объектам (type=LAND_PLOT), тянет borders и сохраняет.
      * @param bool $onlyMissing  true — обновлять только у тех, где borders = null
      * @param int|null $limit    лимит обработанных записей за запуск (null = без лимита)
      * @return array{processed:int, updated:int, skipped:int, failed:int}
@@ -17,7 +18,7 @@ class InvestmentBordersSyncService
     public function sync(bool $onlyMissing = true, ?int $limit = null): array
     {
         $query = AbandonedObject::query()
-            ->where('type', 2)
+            ->where('type', AbandonedObjectTypeEnum::LAND_PLOT->value)
             ->when($onlyMissing, fn ($q) => $q->whereNull('borders'));
 
         $processed = $updated = $skipped = $failed = 0;

--- a/app/Services/ParseObjectsService.php
+++ b/app/Services/ParseObjectsService.php
@@ -57,7 +57,7 @@ class ParseObjectsService
                 "toInspectionDate" => null,
                 "fromEventDate" => null,
                 "toEventDate" => null,
-                "abandonedObjectTypeId" => 1,
+                "abandonedObjectTypeId" => AbandonedObjectTypeEnum::HOUSE->value,
                 "stateTypeId" => 15,
                 "stateGroupId" => 2,
                 "stateSearchCategoryId" => 1,

--- a/database/migrations/2025_08_17_194602_create_objects_table.php
+++ b/database/migrations/2025_08_17_194602_create_objects_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\AbandonedObjectTypeEnum;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
     {
         Schema::create('objects', function (Blueprint $table) {
             $table->id();
-            $table->tinyInteger('type')->default(1);
+            $table->tinyInteger('type')->default(AbandonedObjectTypeEnum::HOUSE->value);
             $table->text('address')->nullable();
             $table->string('coords')->nullable();
             $table->string('eri_id');


### PR DESCRIPTION
## Summary
- replace numeric object type checks with `AbandonedObjectTypeEnum` values
- default object type uses enum in console commands and services
- align database migration with object type enum

## Testing
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ef347748324a02078936c37c478