### PR TITLE
feat: map abandoned object request strategies

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,16 +2,33 @@
 
 namespace App\Providers;
 
+use App\Enums\AbandonedObjectTypeEnum;
+use App\Services\RequestStrategies\AbandonedObjectRequestStrategy;
+use App\Services\RequestStrategies\HouseRequestStrategy;
+use App\Services\RequestStrategies\LandPlotRequestStrategy;
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
+    private const STRATEGY_MAP = [
+        AbandonedObjectTypeEnum::HOUSE->value => HouseRequestStrategy::class,
+        AbandonedObjectTypeEnum::LAND_PLOT->value => LandPlotRequestStrategy::class,
+    ];
+
     /**
      * Register any application services.
      */
     public function register(): void
     {
-        //
+        $this->app->bind(AbandonedObjectRequestStrategy::class, function ($app) {
+            $request = $app->make(Request::class);
+            $type = AbandonedObjectTypeEnum::tryFrom((int) $request->input('type')) ?? AbandonedObjectTypeEnum::HOUSE;
+
+            $strategyClass = self::STRATEGY_MAP[$type->value] ?? HouseRequestStrategy::class;
+
+            return $app->make($strategyClass);
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- map abandoned object types to request strategies in `AppServiceProvider`
- resolve strategies from map instead of match

## Testing
- `./vendor/bin/phpunit` *(fails: Vite manifest not found at: /workspace/eri/public/build/manifest.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aff3fc2c83248f31ae24336567c8